### PR TITLE
close server in goroutine

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -298,7 +298,8 @@ func AuthorizeUser(clientID string, issuer string, redirectURL string) {
 }
 
 func stop(server *http.Server) {
-	server.Close()
+	// run in a goroutine so that the request being served by the server completes
+	go server.Close()
 }
 
 // exchangeCodeForToken trades the authorization code for an access token


### PR DESCRIPTION
A follow-up from the review on https://github.com/cased/cased-cli/pull/18: turns out deferring the shutdown of the server with a goroutine was required to ensure that the response actually makes it back to the user. Without this, I get an empty reply instead of seeing the "authenticated successfully" message.